### PR TITLE
Use Printable rather than StringLiteralConvertible in convenience methods

### DIFF
--- a/library/CoreData/Base/NSManagedObject+SugarRecord.swift
+++ b/library/CoreData/Base/NSManagedObject+SugarRecord.swift
@@ -87,7 +87,7 @@ extension NSManagedObject
     
     :returns: SugarRecord finder with the predicate set
     */
-    public class func by<T: StringLiteralConvertible, R: StringLiteralConvertible>(key: T, equalTo value: R) -> SugarRecordFinder
+    public class func by<T: Printable, R: Printable>(key: T, equalTo value: R) -> SugarRecordFinder
     {
         var finder: SugarRecordFinder = SugarRecordFinder()
         finder.setPredicate(byKey: "\(key)", andValue: "\(value)")
@@ -107,7 +107,7 @@ extension NSManagedObject
     
     :returns: SugarRecord finder with the predicate set
     */
-    public class func sorted<T: StringLiteralConvertible>(by sortingKey: T, ascending: Bool) -> SugarRecordFinder
+    public class func sorted<T: Printable>(by sortingKey: T, ascending: Bool) -> SugarRecordFinder
     {
         var finder: SugarRecordFinder = SugarRecordFinder()
         finder.addSortDescriptor(byKey: "\(sortingKey)", ascending: ascending)


### PR DESCRIPTION
`StringLiteralConvertible` is for objects than can be pulled _from_ strings, not _to_ strings. Try calling `MyEntity.by("attrib", equalTo: 17)` and you'll get a compiler error because 17 isn't `StringLiteralConvertible`

Great library, look forward to using it.
