### PR TITLE
Fixed autosaving behaviour not working

### DIFF
--- a/example/SugarRecordExample/Shared/Controllers/CoreDataTableViewController.swift
+++ b/example/SugarRecordExample/Shared/Controllers/CoreDataTableViewController.swift
@@ -27,6 +27,7 @@ class CoreDataTableViewController: StackTableViewController {
         self.title = "Core Data"
         self.tableView.registerClass(UITableViewCell.self, forCellReuseIdentifier: self.cellIdentifier())
         self.stack = DefaultCDStack(databaseName: "CoreData.sqlite", model: self.model, automigrating: true)
+        //(self.stack as DefaultCDStack).autoSaving = true
         SugarRecord.addStack(self.stack!)
     }
     

--- a/spec/CoreData/DefaultCDStackTests.swift
+++ b/spec/CoreData/DefaultCDStackTests.swift
@@ -132,38 +132,12 @@ class DefaultCDStackTests: XCTestCase
         XCTAssertEqual((stack!.backgroundContext() as SugarRecordCDContext).contextCD.concurrencyType, NSManagedObjectContextConcurrencyType.ConfinementConcurrencyType, "The concurrency type should be MainQueueConcurrencyType")
     }
     
-    func testIfAddObserversForAutosaving()
-    {
-        class MockNotificationCenter: NSNotificationCenter
-        {
-            var addedNotificationName: String = ""
-            private override func addObserverForName(name: String?, object obj: AnyObject?, queue: NSOperationQueue?, usingBlock block: (NSNotification!) -> Void) -> NSObjectProtocol {
-                addedNotificationName = name!
-                return NSObject()
-            }
-        }
-        
-        class MockDefaultStack: DefaultCDStack
-        {
-            lazy var nc: MockNotificationCenter = MockNotificationCenter()
-            override func notificationCenter() -> NSNotificationCenter
-            {
-               return nc
-            }
-
-        }
-        let mockStack: MockDefaultStack = MockDefaultStack(databaseName: "test", automigrating: false)
-        mockStack.addObservers()
-        let notificationCenter: MockNotificationCenter! = mockStack.notificationCenter() as MockNotificationCenter
-        XCTAssertEqual(notificationCenter.addedNotificationName, DefaultCDStack.Constants.autoSavingKVOKey, "The notification key should be \(DefaultCDStack.Constants.autoSavingKVOKey)")
-    }
-    
     func testIfTheAutoSavingClosureIsCalledDependingOnTheAutoSavingProperty()
     {
         class MockDefaultStack: DefaultCDStack
         {
             var autoSavingClosureCalled: Bool = true
-            override func autoSavingClosure() -> (notification: NSNotification!) -> ()
+            override func autoSavingClosure() -> () -> ()
             {
                 return { [weak self] (notification) -> Void in
                     self!.autoSavingClosureCalled = true
@@ -172,7 +146,6 @@ class DefaultCDStackTests: XCTestCase
         }
         let mockStack: MockDefaultStack = MockDefaultStack(databaseName: "test", automigrating: false)
         mockStack.initialize()
-        mockStack.notificationCenter().postNotificationName(DefaultCDStack.Constants.autoSavingKVOKey, object: nil)
         mockStack.autoSaving = true
         XCTAssertTrue(mockStack.autoSavingClosureCalled, "The AutoSavingClosure should be called if the autosaving is enabled")
         mockStack.autoSavingClosureCalled = false


### PR DESCRIPTION
### What?
Autosaving was not working properly on `DefaultCDStack`. Now if you enable it every time you save something it's automatically persisted into the database and you don't have to wait until the app is sent to the background.

Solves #101 