### PR TITLE
Podspec updated platform to 7.0

### DIFF
--- a/SugarRecord.podspec
+++ b/SugarRecord.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name = 'SugarRecord'
   s.version = '1.0.6'
-  s.platform = :ios, '8.0'
+  s.platform = :ios, '7.0'
   s.license = 'MIT'
   s.summary = 'CoreData management library implemented with the sugar Swift language'
   s.homepage = 'https://github.com/SugarRecord/SugarRecord'


### PR DESCRIPTION
### What
Solves this #110 

SugarRecord is expected to be supported from 7.0 (Swift has support for it) but the podspect platform was 8.0. I've updated it to 7.0.