### PR TITLE
Fix: iterator

### DIFF
--- a/library/Core/SugarRecordResults.swift
+++ b/library/Core/SugarRecordResults.swift
@@ -105,7 +105,7 @@ public class SRResultsGenerator: GeneratorType {
     init(results: SugarRecordResults)
     {
         self.results = results
-        nextIndex = 0
+        nextIndex = results.count - 1
     }
     
     public func next() -> AnyObject?


### PR DESCRIPTION
I found a iterator bug.

Would you read sample code as follow?
```
let results : SugarRecordResults = User.all().sorted(by: "age", ascending: false).find()
let iterator = results.generate()
while let result = iterator.next() {
    some processing....   
}
```
nextIndex should have max results array number at SRResultsGenerator#init.
