### PR TITLE
Fixed for Swift 1.2

### DIFF
--- a/example/SugarRecordExample/Shared/Controllers/CoreDataTableViewController.swift
+++ b/example/SugarRecordExample/Shared/Controllers/CoreDataTableViewController.swift
@@ -16,7 +16,7 @@ class CoreDataTableViewController: StackTableViewController {
     var data: SugarRecordResults?
     internal let model: NSManagedObjectModel = {
         let modelPath: NSString = NSBundle.mainBundle().pathForResource("Models", ofType: "momd")!
-        let model: NSManagedObjectModel = NSManagedObjectModel(contentsOfURL: NSURL(fileURLWithPath: modelPath)!)!
+        let model: NSManagedObjectModel = NSManagedObjectModel(contentsOfURL: NSURL(fileURLWithPath: modelPath as! String)!)!
         return model
         }()
     
@@ -27,7 +27,7 @@ class CoreDataTableViewController: StackTableViewController {
         self.title = "Core Data"
         self.tableView.registerClass(UITableViewCell.self, forCellReuseIdentifier: self.cellIdentifier())
         self.stack = DefaultCDStack(databaseName: "CoreData.sqlite", model: self.model, automigrating: true)
-        (self.stack as DefaultCDStack).autoSaving = true
+        (self.stack as! DefaultCDStack).autoSaving = true
         SugarRecord.addStack(self.stack!)
     }
     
@@ -37,7 +37,7 @@ class CoreDataTableViewController: StackTableViewController {
     @IBAction override func add(sender: AnyObject?) {
         let formatter = NSDateFormatter()
         formatter.dateFormat = "MMMM d yyyy - HH:mm:ss"
-        let model = CoreDataModel.create() as CoreDataModel
+        let model = CoreDataModel.create() as! CoreDataModel
         model.text = formatter.stringFromDate(NSDate())
         model.save()
         self.fetchData()
@@ -61,13 +61,13 @@ class CoreDataTableViewController: StackTableViewController {
     //MARK: - Cell
     
     override func configureCell(cell: UITableViewCell, indexPath: NSIndexPath) {
-        let model = self.data![indexPath.row] as CoreDataModel
+        let model = self.data![indexPath.row] as! CoreDataModel
         cell.textLabel?.text = model.text
     }
     
     override func tableView(tableView: UITableView, commitEditingStyle editingStyle: UITableViewCellEditingStyle, forRowAtIndexPath indexPath: NSIndexPath) {
         if (editingStyle == .Delete) {
-            let model = self.data![indexPath.row] as CoreDataModel
+            let model = self.data![indexPath.row] as! CoreDataModel
             model.beginWriting().delete().endWriting()
             self.fetchData()
             tableView.deleteRowsAtIndexPaths([indexPath], withRowAnimation: .Fade)

--- a/example/SugarRecordExample/Shared/Controllers/RealmTableViewController.swift
+++ b/example/SugarRecordExample/Shared/Controllers/RealmTableViewController.swift
@@ -31,7 +31,7 @@ class RealmTableViewController: StackTableViewController
     @IBAction override func add(sender: AnyObject?) {
         let formatter = NSDateFormatter()
         formatter.dateFormat = "MMMM d yyyy - HH:mm:ss"
-        let model = RealmModel.create() as RealmModel
+        let model = RealmModel.create() as! RealmModel
         model.name = formatter.stringFromDate(NSDate())
         model.save()
         self.fetchData()
@@ -57,14 +57,14 @@ class RealmTableViewController: StackTableViewController
     override func configureCell(cell: UITableViewCell, indexPath: NSIndexPath) {
         let formatter = NSDateFormatter()
         formatter.dateFormat = "MMMM d yyyy - HH:mm:ss"
-        let model = self.data![indexPath.row] as RealmModel
+        let model = self.data![indexPath.row] as! RealmModel
         cell.textLabel?.text = model.name
         cell.detailTextLabel?.text = formatter.stringFromDate(model.date)
     }
     
     override func tableView(tableView: UITableView, commitEditingStyle editingStyle: UITableViewCellEditingStyle, forRowAtIndexPath indexPath: NSIndexPath) {
         if (editingStyle == .Delete) {
-            let model = self.data![indexPath.row] as RealmModel
+            let model = self.data![indexPath.row] as! RealmModel
             model.beginWriting().delete().endWriting()
             self.fetchData()
             tableView.deleteRowsAtIndexPaths([indexPath], withRowAnimation: .Fade)

--- a/example/SugarRecordExample/Shared/Controllers/RestKitTableViewController.swift
+++ b/example/SugarRecordExample/Shared/Controllers/RestKitTableViewController.swift
@@ -26,7 +26,7 @@ class RestKitTableViewController: CoreDataTableViewController {
     @IBAction override func add(sender: AnyObject?) {
         let names = ["Sweet", "Chocolate", "Cookie", "Fudge", "Caramel"]
         let randomIndex = Int(arc4random_uniform(UInt32(names.count)))
-        let model = RestKitModel.create() as RestKitModel
+        let model = RestKitModel.create() as! RestKitModel
         model.date = NSDate()
         model.name = names[randomIndex]
         model.save()
@@ -48,8 +48,9 @@ class RestKitTableViewController: CoreDataTableViewController {
     override func configureCell(cell: UITableViewCell, indexPath: NSIndexPath) {
         let formatter = NSDateFormatter()
         formatter.dateFormat = "MMMM d yyyy - HH:mm:ss"
-        let model = self.data![indexPath.row] as RestKitModel
+        let model = self.data![indexPath.row] as! RestKitModel
         cell.textLabel!.text = model.name
+        println("Date: \(model.date)")
         cell.detailTextLabel!.text = formatter.stringFromDate(model.date)
     }
     

--- a/example/SugarRecordExample/Shared/Controllers/StackTableViewController.swift
+++ b/example/SugarRecordExample/Shared/Controllers/StackTableViewController.swift
@@ -75,7 +75,7 @@ class StackTableViewController: UITableViewController
     }
 
     override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCellWithIdentifier(self.cellIdentifier(), forIndexPath: indexPath) as UITableViewCell
+        let cell = tableView.dequeueReusableCellWithIdentifier(self.cellIdentifier(), forIndexPath: indexPath) as! UITableViewCell
         self.configureCell(cell, indexPath: indexPath)
         return cell
     }

--- a/example/SugarRecordExample/Shared/Controllers/StacksTableViewController.swift
+++ b/example/SugarRecordExample/Shared/Controllers/StacksTableViewController.swift
@@ -31,7 +31,7 @@ class StacksTableViewController: UITableViewController {
     }
 
     override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCellWithIdentifier("StackCell", forIndexPath: indexPath) as UITableViewCell
+        let cell = tableView.dequeueReusableCellWithIdentifier("StackCell", forIndexPath: indexPath) as! UITableViewCell
 
         cell.textLabel?.text = self.stacks[indexPath.row]
 

--- a/library/Core/SugarRecordFinder.swift
+++ b/library/Core/SugarRecordFinder.swift
@@ -108,7 +108,7 @@ public class SugarRecordFinder
         if self.predicate != nil {
             SugarRecordLogger.logLevelWarn.log("You are overriding an existing predicate")
         }
-        self.setPredicate(predicateString)
+        self.setPredicate(predicateString as! String)
         return self
     }
     
@@ -414,7 +414,7 @@ public class SugarRecordFinder
     public func count(inContext context:SugarRecordContext) -> Int
     {
         if (stackType == SugarRecordEngine.SugarRecordEngineCoreData) {
-            return (context as SugarRecordCDContext).count(self.objectClass!, predicate: self.predicate)
+            return (context as! SugarRecordCDContext).count(self.objectClass!, predicate: self.predicate)
         }
         else {
             return find().count

--- a/library/CoreData/Base/DefaultCDStack.swift
+++ b/library/CoreData/Base/DefaultCDStack.swift
@@ -452,7 +452,7 @@ public class DefaultCDStack: SugarRecordStackProtocol
     */
     internal class func databasePathURLFromName(name: String) -> NSURL
     {
-        let documentsPath: String = NSSearchPathForDirectoriesInDomains(.ApplicationSupportDirectory, .UserDomainMask, true)[0] as String
+        let documentsPath: String = NSSearchPathForDirectoriesInDomains(.ApplicationSupportDirectory, .UserDomainMask, true)[0] as! String
         let mainBundleInfo: [NSObject: AnyObject] = NSBundle.mainBundle().infoDictionary!
         let applicationPath: String = documentsPath.stringByAppendingPathComponent("store")
         
@@ -538,7 +538,7 @@ public extension NSManagedObjectContext
     :param: notification Notification that fired this method
     */
     func contextWillSave(notification: NSNotification) {
-        let context: NSManagedObjectContext = notification.object as NSManagedObjectContext
+        let context: NSManagedObjectContext = notification.object as! NSManagedObjectContext
         let insertedObjects: NSSet = context.insertedObjects
         if insertedObjects.count == 0{
             return

--- a/library/CoreData/Base/NSManagedObject+SugarRecord.swift
+++ b/library/CoreData/Base/NSManagedObject+SugarRecord.swift
@@ -73,7 +73,7 @@ extension NSManagedObject
     public class func by(predicateString: NSString) -> SugarRecordFinder
     {
         var finder: SugarRecordFinder = SugarRecordFinder()
-        finder.setPredicate(predicateString)
+        finder.setPredicate(predicateString as! String)
         finder.objectClass = self
         finder.stackType = stackType()
         return finder

--- a/library/CoreData/Base/SugarRecordCDContext.swift
+++ b/library/CoreData/Base/SugarRecordCDContext.swift
@@ -64,7 +64,7 @@ public class SugarRecordCDContext: SugarRecordContext
     */
     public func createObject(objectClass: AnyClass) -> AnyObject?
     {
-        let managedObjectClass: NSManagedObject.Type = objectClass as NSManagedObject.Type
+        let managedObjectClass: NSManagedObject.Type = objectClass as! NSManagedObject.Type
         var object: AnyObject = NSEntityDescription.insertNewObjectForEntityForName(managedObjectClass.modelName(), inManagedObjectContext: self.contextCD)
         return object
     }
@@ -76,7 +76,7 @@ public class SugarRecordCDContext: SugarRecordContext
     */
     public func insertObject(object: AnyObject)
     {
-        moveObject(object as NSManagedObject, inContext: self.contextCD)
+        moveObject(object as! NSManagedObject, inContext: self.contextCD)
     }
     
     /**
@@ -108,7 +108,7 @@ public class SugarRecordCDContext: SugarRecordContext
     public class func fetchRequest(fromFinder finder: SugarRecordFinder) -> NSFetchRequest
     {
         let objectClass: NSObject.Type = finder.objectClass!
-        let managedObjectClass: NSManagedObject.Type = objectClass as NSManagedObject.Type
+        let managedObjectClass: NSManagedObject.Type = objectClass as! NSManagedObject.Type
         let fetchRequest: NSFetchRequest = NSFetchRequest(entityName: managedObjectClass.modelName())
         fetchRequest.predicate = finder.predicate
         var sortDescriptors: [NSSortDescriptor] = finder.sortDescriptors
@@ -179,7 +179,7 @@ public class SugarRecordCDContext: SugarRecordContext
     */
     public func count(objectClass: AnyClass, predicate: NSPredicate? = nil) -> Int
     {
-        let managedObjectClass: NSManagedObject.Type = objectClass as NSManagedObject.Type
+        let managedObjectClass: NSManagedObject.Type = objectClass as! NSManagedObject.Type
         let fetchRequest: NSFetchRequest = NSFetchRequest(entityName: managedObjectClass.modelName())
         fetchRequest.predicate = predicate
         var error: NSError?
@@ -201,7 +201,7 @@ public class SugarRecordCDContext: SugarRecordContext
     func moveObject(object: NSManagedObject, inContext context: NSManagedObjectContext) -> NSManagedObject?
     {
         var error: NSError?
-        let objectInContext: NSManagedObject? = context.existingObjectWithID(object.objectID, error: &error)?
+        let objectInContext: NSManagedObject? = context.existingObjectWithID(object.objectID, error: &error)
         if error != nil {
             let exception: NSException = NSException(name: "Database operations", reason: "Couldn't move the object into the new context", userInfo: nil)
             SugarRecord.handle(exception)

--- a/library/CoreData/Base/iCloudCDStack.swift
+++ b/library/CoreData/Base/iCloudCDStack.swift
@@ -17,9 +17,9 @@ public struct iCloudData
     /// Is the full AppID (including the Team Prefix). It's needed to change tihs to match the Team Prefix found in the iOS Provisioning profile
     internal let iCloudAppID: String
     /// Is the name of the directory where the database will be stored in. It should always end with .nosync
-    internal let iCloudDataDirectoryName: String = "Data.nosync"
+    internal var iCloudDataDirectoryName: String = "Data.nosync"
     /// Is the name of the directory where the database change logs will be stored in
-    internal let iCloudLogsDirectory: String = "Logs"
+    internal var iCloudLogsDirectory: String = "Logs"
     
     /**
     Note:
@@ -52,7 +52,7 @@ public class iCloudCDStack: DefaultCDStack
     //MARK: - Properties
     
     /// iCloud Data struct with the information
-    private let icloudData: iCloudData?
+    private var icloudData: iCloudData?
     
     /// Notification center used for iCloud Notifications
     lazy var notificationCenter: NSNotificationCenter = NSNotificationCenter.defaultCenter()
@@ -154,7 +154,7 @@ public class iCloudCDStack: DefaultCDStack
         SugarRecordLogger.logLevelInfo.log("Initializing the stack: \(self.stackDescription)")
         createManagedObjecModelIfNeeded()
         persistentStoreCoordinator = createPersistentStoreCoordinator()
-        addDatabase(foriCloud: true, self.dataBaseAddedClosure())
+        addDatabase(foriCloud: true, completionClosure: self.dataBaseAddedClosure())
     }
     
     /**

--- a/library/Realm/DefaultREALMStack.swift
+++ b/library/Realm/DefaultREALMStack.swift
@@ -115,7 +115,7 @@ public class DefaultREALMStack: SugarRecordStackProtocol
     */
     public func removeDatabase()
     {
-        let documentsPath: String = NSSearchPathForDirectoriesInDomains(.DocumentDirectory, .UserDomainMask, true)[0] as String
+        let documentsPath: String = NSSearchPathForDirectoriesInDomains(.DocumentDirectory, .UserDomainMask, true)[0] as! String
         let databaseName: String = documentsPath.stringByAppendingPathComponent("default.realm")
         var error: NSError?
         NSFileManager.defaultManager().removeItemAtPath(databaseName, error: &error)

--- a/library/Realm/RLMObject+SugarRecord.swift
+++ b/library/Realm/RLMObject+SugarRecord.swift
@@ -75,7 +75,7 @@ extension RLMObject
     public class func by(predicateString: NSString) -> SugarRecordFinder
     {
         var finder: SugarRecordFinder = SugarRecordFinder()
-        finder.setPredicate(predicateString)
+        finder.setPredicate(predicateString as! String)
         finder.objectClass = self
         finder.stackType = stackType()
         return finder

--- a/library/Realm/RLMResults+SugarRecordResults.swift
+++ b/library/Realm/RLMResults+SugarRecordResults.swift
@@ -21,7 +21,7 @@ import Realm
     func objectAtIndex(index: UInt, finder: SugarRecordFinder) -> AnyObject!
     {
         let (firstIndex, lastIndex) = indexes(finder: finder)
-        return self.objectAtIndex(firstIndex + index)
+        return self.objectAtIndex(UInt(firstIndex) + index)
     }
     
     func firstObject(#finder: SugarRecordFinder) -> AnyObject!

--- a/library/Realm/SugarRecordRLMContext.swift
+++ b/library/Realm/SugarRecordRLMContext.swift
@@ -61,7 +61,7 @@ public class SugarRecordRLMContext: SugarRecordContext
     */
     public func createObject(objectClass: AnyClass) -> AnyObject?
     {
-        let objectClass: RLMObject.Type = objectClass as RLMObject.Type
+        let objectClass: RLMObject.Type = objectClass as! RLMObject.Type
         return objectClass()
     }
     
@@ -72,7 +72,7 @@ public class SugarRecordRLMContext: SugarRecordContext
     */
     public func insertObject(object: AnyObject)
     {
-        self.realmContext.addObject(object as RLMObject)
+        self.realmContext.addObject(object as! RLMObject)
     }
     
     /**
@@ -84,7 +84,7 @@ public class SugarRecordRLMContext: SugarRecordContext
     */
     public func find(finder: SugarRecordFinder) -> SugarRecordResults
     {
-        let objectClass: RLMObject.Type = finder.objectClass as RLMObject.Type
+        let objectClass: RLMObject.Type = finder.objectClass as! RLMObject.Type
         var filteredObjects: RLMResults! = nil
         if finder.predicate != nil {
             filteredObjects = objectClass.objectsWithPredicate(finder.predicate)
@@ -108,7 +108,7 @@ public class SugarRecordRLMContext: SugarRecordContext
     */
     public func deleteObject(object: AnyObject) -> SugarRecordContext
     {
-        self.realmContext.deleteObject(object as RLMObject)
+        self.realmContext.deleteObject(object as! RLMObject)
         return self
     }
     
@@ -136,7 +136,7 @@ public class SugarRecordRLMContext: SugarRecordContext
     */
     public func count(objectClass: AnyClass, predicate: NSPredicate? = nil) -> Int
     {
-        let objectClass: RLMObject.Type = objectClass as RLMObject.Type
+        let objectClass: RLMObject.Type = objectClass as! RLMObject.Type
         var objects: RLMResults? = nil
         if predicate != nil {
             objects = objectClass.objectsWithPredicate(predicate)


### PR DESCRIPTION
"Forced failable conversion now uses the as! operator."

"Immutable (let) properties in struct and class initializers have been revised to standardize on a general “lets are singly initialized but never reassigned or mutated” model."