### PR TITLE
Fixed RestKit example and fixed iCloud stack error

### DIFF
--- a/example/SugarRecordExample.xcodeproj/project.pbxproj
+++ b/example/SugarRecordExample.xcodeproj/project.pbxproj
@@ -33,6 +33,8 @@
 		3DF36C881A38F5A800A73311 /* Models.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 3DF36C7E1A38F5A800A73311 /* Models.xcdatamodeld */; };
 		3DF36C971A39059D00A73311 /* Realm.framework in Copy Realm */ = {isa = PBXBuildFile; fileRef = 3DF36C921A39057F00A73311 /* Realm.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		3DF36C991A3905CE00A73311 /* libc++.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 3DF36C981A3905CE00A73311 /* libc++.dylib */; };
+		A290563A1A9634B600F47010 /* iCloudViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A29056391A9634B600F47010 /* iCloudViewController.swift */; };
+		A29056431A9638DA00F47010 /* ICloudModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A29056421A9638DA00F47010 /* ICloudModel.swift */; };
 		E14DAC441A3A0448008AC983 /* RestKitTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E14DAC431A3A0448008AC983 /* RestKitTableViewController.swift */; };
 		E14DAC451A3A053B008AC983 /* RestkitCDStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1526DEE1A38A05C00BC6E1E /* RestkitCDStack.swift */; };
 		E1526DD11A389F3200BC6E1E /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E1526DD01A389F3200BC6E1E /* CoreData.framework */; };
@@ -100,6 +102,8 @@
 		3DF36C931A39057F00A73311 /* RLMSupport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RLMSupport.swift; path = ../../project/frameworks/realm/RLMSupport.swift; sourceTree = "<group>"; };
 		3DF36C981A3905CE00A73311 /* libc++.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libc++.dylib"; path = "usr/lib/libc++.dylib"; sourceTree = SDKROOT; };
 		93387547534B0073B3B4B328 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		A29056391A9634B600F47010 /* iCloudViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = iCloudViewController.swift; sourceTree = "<group>"; };
+		A29056421A9638DA00F47010 /* ICloudModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ICloudModel.swift; sourceTree = "<group>"; };
 		BED8AACE3217C166E177ACA9 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
 		E14DAC421A3A01BB008AC983 /* SugarRecordExample-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "SugarRecordExample-Bridging-Header.h"; path = "Supporting Files/SugarRecordExample-Bridging-Header.h"; sourceTree = "<group>"; };
 		E14DAC431A3A0448008AC983 /* RestKitTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RestKitTableViewController.swift; sourceTree = "<group>"; };
@@ -194,11 +198,12 @@
 		3DF36C781A38F5A800A73311 /* Controllers */ = {
 			isa = PBXGroup;
 			children = (
+				3DF36C7A1A38F5A800A73311 /* StacksTableViewController.swift */,
 				3DF36C791A38F5A800A73311 /* CoreDataTableViewController.swift */,
 				E14DAC431A3A0448008AC983 /* RestKitTableViewController.swift */,
-				3DF36C7A1A38F5A800A73311 /* StacksTableViewController.swift */,
-				3DF36C7B1A38F5A800A73311 /* StackTableViewController.swift */,
 				3D4754DE1A4C7C5200479D16 /* RealmTableViewController.swift */,
+				A29056391A9634B600F47010 /* iCloudViewController.swift */,
+				3DF36C7B1A38F5A800A73311 /* StackTableViewController.swift */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -209,6 +214,7 @@
 				3DF36C7D1A38F5A800A73311 /* CoreDataModel.swift */,
 				E197C9CC1A3F97AA000533A4 /* RestKitModel.swift */,
 				3DF36C7E1A38F5A800A73311 /* Models.xcdatamodeld */,
+				A29056421A9638DA00F47010 /* ICloudModel.swift */,
 				3D4754E01A4C7CD000479D16 /* RealmModel.swift */,
 			);
 			path = Models;
@@ -449,6 +455,7 @@
 			files = (
 				3D4754E71A4C7D3400479D16 /* RLMSupport.swift in Sources */,
 				3D4754ED1A4C7F5500479D16 /* SugarRecordRLMContext.swift in Sources */,
+				A290563A1A9634B600F47010 /* iCloudViewController.swift in Sources */,
 				3D4754EC1A4C7F5300479D16 /* RLMObjectMigration.swift in Sources */,
 				E197C9CD1A3F97AA000533A4 /* RestKitModel.swift in Sources */,
 				3D4754EB1A4C7F5000479D16 /* RLMObject+SugarRecord.swift in Sources */,
@@ -475,6 +482,7 @@
 				3DF36C841A38F5A800A73311 /* CoreDataTableViewController.swift in Sources */,
 				3D4754DF1A4C7C5200479D16 /* RealmTableViewController.swift in Sources */,
 				3DF36C881A38F5A800A73311 /* Models.xcdatamodeld in Sources */,
+				A29056431A9638DA00F47010 /* ICloudModel.swift in Sources */,
 				3D47547F1A4C460100479D16 /* SugarRecordFinder.swift in Sources */,
 				E1526DF71A38A05C00BC6E1E /* NSManagedObject+SugarRecord.swift in Sources */,
 			);

--- a/example/SugarRecordExample/Resources/Main.storyboard
+++ b/example/SugarRecordExample/Resources/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6254" systemVersion="13F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="M9n-eZ-gNF">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6254" systemVersion="14D72i" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="M9n-eZ-gNF">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6247"/>
     </dependencies>
@@ -13,10 +13,18 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <prototypes>
-                            <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="StackCell" id="EFT-XC-5uz">
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="StackCell" textLabel="nT7-wQ-Af1" style="IBUITableViewCellStyleDefault" id="EFT-XC-5uz">
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="EFT-XC-5uz" id="tjD-Pf-2tl">
                                     <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Title" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="nT7-wQ-Af1">
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                            <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
                                 </tableViewCellContentView>
                             </tableViewCell>
                         </prototypes>
@@ -30,86 +38,6 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Q1h-H6-zjP" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="207" y="1067"/>
-        </scene>
-        <!--Rest Kit Table View Controller-->
-        <scene sceneID="nbU-Cw-qzb">
-            <objects>
-                <tableViewController storyboardIdentifier="RestKitTableViewController" id="cZb-64-1um" customClass="RestKitTableViewController" customModule="SugarRecordExample" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" id="p2c-ia-8hj">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                        <prototypes>
-                            <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="ModelCell" textLabel="Pyh-da-vva" detailTextLabel="5FT-I2-I8F" style="IBUITableViewCellStyleValue1" id="mCz-bX-p4m">
-                                <autoresizingMask key="autoresizingMask"/>
-                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="mCz-bX-p4m" id="W44-ji-sYF">
-                                    <autoresizingMask key="autoresizingMask"/>
-                                    <subviews>
-                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Title" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Pyh-da-vva">
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                            <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Detail" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="5FT-I2-I8F">
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                            <color key="textColor" red="0.55686274509803924" green="0.55686274509803924" blue="0.57647058823529407" alpha="1" colorSpace="calibratedRGB"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                    </subviews>
-                                </tableViewCellContentView>
-                            </tableViewCell>
-                        </prototypes>
-                        <connections>
-                            <outlet property="dataSource" destination="cZb-64-1um" id="OI6-st-fvy"/>
-                            <outlet property="delegate" destination="cZb-64-1um" id="RB5-Fq-aXQ"/>
-                        </connections>
-                    </tableView>
-                </tableViewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="LwP-WL-w9o" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="845" y="1067"/>
-        </scene>
-        <!--Realm Table View Controller-->
-        <scene sceneID="G69-hR-yGg">
-            <objects>
-                <tableViewController storyboardIdentifier="RealmTableViewController" id="BEW-aQ-rbn" customClass="RealmTableViewController" customModule="SugarRecordExample" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" id="Yrb-ex-pYU">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                        <prototypes>
-                            <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="ModelCell" textLabel="skm-Uk-kXS" detailTextLabel="xAl-x6-EtG" style="IBUITableViewCellStyleValue1" id="RrG-WB-wVP">
-                                <autoresizingMask key="autoresizingMask"/>
-                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="RrG-WB-wVP" id="DIc-OD-fDz">
-                                    <autoresizingMask key="autoresizingMask"/>
-                                    <subviews>
-                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Title" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="skm-Uk-kXS">
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                            <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Detail" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="xAl-x6-EtG">
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                            <color key="textColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="calibratedRGB"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                    </subviews>
-                                </tableViewCellContentView>
-                            </tableViewCell>
-                        </prototypes>
-                        <connections>
-                            <outlet property="dataSource" destination="BEW-aQ-rbn" id="ZX3-kl-FSg"/>
-                            <outlet property="delegate" destination="BEW-aQ-rbn" id="G1z-ZJ-Pdl"/>
-                        </connections>
-                    </tableView>
-                </tableViewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="eis-vU-nfp" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="1477" y="1067"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="0NB-L6-J9t">

--- a/example/SugarRecordExample/Shared/Controllers/RealmTableViewController.swift
+++ b/example/SugarRecordExample/Shared/Controllers/RealmTableViewController.swift
@@ -21,6 +21,7 @@ class RealmTableViewController: StackTableViewController
     override func viewDidLoad() {
         super.viewDidLoad()
         self.title = "Realm"
+         self.tableView.registerClass(UITableViewCell.self, forCellReuseIdentifier: self.cellIdentifier())
         self.stack = DefaultREALMStack(stackName: "Realm", stackDescription: "")
         SugarRecord.addStack(self.stack!)
     }

--- a/example/SugarRecordExample/Shared/Controllers/RestKitTableViewController.swift
+++ b/example/SugarRecordExample/Shared/Controllers/RestKitTableViewController.swift
@@ -8,7 +8,16 @@
 
 import UIKit
 
-class RestKitTableViewController: CoreDataTableViewController {
+class RestKitTableViewController: StackTableViewController {
+    
+    //MARK: - Attributes
+    
+    var data: SugarRecordResults?
+    internal let model: NSManagedObjectModel = {
+        let modelPath: NSString = NSBundle.mainBundle().pathForResource("Models", ofType: "momd")!
+        let model: NSManagedObjectModel = NSManagedObjectModel(contentsOfURL: NSURL(fileURLWithPath: modelPath)!)!
+        return model
+        }()
 
     //MARK: - Viewcontroller Lifecycle
     
@@ -42,6 +51,11 @@ class RestKitTableViewController: CoreDataTableViewController {
         self.data = RestKitModel.all().sorted(by: "date", ascending: false).find()
     }
     
+    override func dataCount() -> Int {
+        if (data == nil) { return 0 }
+        else { return data!.count }
+    }
+    
     
     //MARK: - Cell
     
@@ -49,8 +63,17 @@ class RestKitTableViewController: CoreDataTableViewController {
         let formatter = NSDateFormatter()
         formatter.dateFormat = "MMMM d yyyy - HH:mm:ss"
         let model = self.data![indexPath.row] as RestKitModel
-        cell.textLabel!.text = model.name
-        cell.detailTextLabel!.text = formatter.stringFromDate(model.date)
+        cell.textLabel?.text = model.name
+        cell.detailTextLabel?.text = formatter.stringFromDate(model.date)
+    }
+    
+    override func tableView(tableView: UITableView, commitEditingStyle editingStyle: UITableViewCellEditingStyle, forRowAtIndexPath indexPath: NSIndexPath) {
+        if (editingStyle == .Delete) {
+            let model = self.data![indexPath.row] as RestKitModel
+            model.beginWriting().delete().endWriting()
+            self.fetchData()
+            tableView.deleteRowsAtIndexPaths([indexPath], withRowAnimation: .Fade)
+        }
     }
     
     override func cellIdentifier() -> String {

--- a/example/SugarRecordExample/Shared/Controllers/StackTableViewController.swift
+++ b/example/SugarRecordExample/Shared/Controllers/StackTableViewController.swift
@@ -75,7 +75,7 @@ class StackTableViewController: UITableViewController
     }
 
     override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCellWithIdentifier(self.cellIdentifier(), forIndexPath: indexPath) as UITableViewCell
+        let cell = UITableViewCell(style: UITableViewCellStyle.Subtitle, reuseIdentifier: cellIdentifier())
         self.configureCell(cell, indexPath: indexPath)
         return cell
     }

--- a/example/SugarRecordExample/Shared/Controllers/StacksTableViewController.swift
+++ b/example/SugarRecordExample/Shared/Controllers/StacksTableViewController.swift
@@ -13,7 +13,8 @@ class StacksTableViewController: UITableViewController {
     var stacks: [String] = [
         "CoreData",
         "RestKit",
-        "Realm"
+        "Realm",
+        "iCloud"
     ]
 
     override func viewDidLoad() {
@@ -48,10 +49,13 @@ class StacksTableViewController: UITableViewController {
             viewController = CoreDataTableViewController()
             
         case "RestKit":
-            viewController = storyBoard.instantiateViewControllerWithIdentifier("RestKitTableViewController") as? UITableViewController
+            viewController = RestKitTableViewController()
             
         case "Realm":
-            viewController = storyBoard.instantiateViewControllerWithIdentifier("RealmTableViewController") as? UITableViewController
+            viewController = RealmTableViewController()
+            
+        case "iCloud":
+            viewController = iCloudViewController()
             
         default:
             println("View Controller not found for stack: \(stack)")

--- a/example/SugarRecordExample/Shared/Controllers/iCloudViewController.swift
+++ b/example/SugarRecordExample/Shared/Controllers/iCloudViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import CoreData
 
 class iCloudViewController: StackTableViewController {
     
@@ -25,16 +26,19 @@ class iCloudViewController: StackTableViewController {
         super.viewDidLoad()
         self.title = "iCloud"
         self.tableView.registerClass(UITableViewCell.self, forCellReuseIdentifier: self.cellIdentifier())
+        
         let data = iCloudData(iCloudAppID: "com.sugarrecord.example.SugarRecordExample", iCloudDataDirectoryName: "data.nosync", iCloudLogsDirectory: "")
         self.stack = iCloudCDStack(databaseName: "iCloud.sqlite", model: self.model, icloudData: data)
         (self.stack as iCloudCDStack).autoSaving = true
         SugarRecord.addStack(self.stack!)
+        
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: "icloudInitialized", name: "iCloudStackInitialized", object: nil)
     }
-
-    override func didReceiveMemoryWarning() {
-        super.didReceiveMemoryWarning()
-        // Dispose of any resources that can be recreated.
+    
+    override func viewWillAppear(animated: Bool) {
+        // Stop StackTableViewController's fetchData from happening
     }
+    
     
     //MARK: - Actions
     
@@ -47,6 +51,15 @@ class iCloudViewController: StackTableViewController {
         self.fetchData()
         let indexPath = NSIndexPath(forRow: 0, inSection: 0)
         tableView.insertRowsAtIndexPaths([indexPath], withRowAnimation: .Top)
+    }
+    
+    //MARK: - Listeners
+    
+    func icloudInitialized() {
+        dispatch_async(dispatch_get_main_queue(), {
+            self.fetchData()
+            self.tableView.reloadData()
+        })
     }
     
     

--- a/example/SugarRecordExample/Shared/Controllers/iCloudViewController.swift
+++ b/example/SugarRecordExample/Shared/Controllers/iCloudViewController.swift
@@ -1,14 +1,14 @@
 //
-//  RestKitTableViewController.swift
+//  iCloudViewController.swift
 //  SugarRecordExample
 //
-//  Created by Robert Dougan on 11/12/14.
-//  Copyright (c) 2014 Robert Dougan. All rights reserved.
+//  Created by David Chavez on 2/19/15.
+//  Copyright (c) 2015 David Chavez. All rights reserved.
 //
 
 import UIKit
 
-class RestKitTableViewController: StackTableViewController {
+class iCloudViewController: StackTableViewController {
     
     //MARK: - Attributes
     
@@ -19,26 +19,30 @@ class RestKitTableViewController: StackTableViewController {
         return model
         }()
 
-    //MARK: - Viewcontroller Lifecycle
+    //MARK: - ViewController Lifecycle
     
-    typealias T = NSManagedObject
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.title = "RestKit"
-         self.tableView.registerClass(UITableViewCell.self, forCellReuseIdentifier: self.cellIdentifier())
-        self.stack = DefaultCDStack(databaseName: "RestKit.sqlite", model: self.model, automigrating: true)
+        self.title = "iCloud"
+        self.tableView.registerClass(UITableViewCell.self, forCellReuseIdentifier: self.cellIdentifier())
+        let data = iCloudData(iCloudAppID: "com.sugarrecord.example.SugarRecordExample", iCloudDataDirectoryName: "data.nosync", iCloudLogsDirectory: "")
+        self.stack = iCloudCDStack(databaseName: "iCloud.sqlite", model: self.model, icloudData: data)
+        (self.stack as iCloudCDStack).autoSaving = true
         SugarRecord.addStack(self.stack!)
     }
-    
+
+    override func didReceiveMemoryWarning() {
+        super.didReceiveMemoryWarning()
+        // Dispose of any resources that can be recreated.
+    }
     
     //MARK: - Actions
     
     @IBAction override func add(sender: AnyObject?) {
-        let names = ["Sweet", "Chocolate", "Cookie", "Fudge", "Caramel"]
-        let randomIndex = Int(arc4random_uniform(UInt32(names.count)))
-        let model = RestKitModel.create() as RestKitModel
-        model.date = NSDate()
-        model.name = names[randomIndex]
+        let formatter = NSDateFormatter()
+        formatter.dateFormat = "MMMM d yyyy - HH:mm:ss"
+        let model = ICloudModel.create() as ICloudModel
+        model.text = formatter.stringFromDate(NSDate())
         model.save()
         self.fetchData()
         let indexPath = NSIndexPath(forRow: 0, inSection: 0)
@@ -49,7 +53,7 @@ class RestKitTableViewController: StackTableViewController {
     //MARK: - Data Source
     
     override func fetchData() {
-        self.data = RestKitModel.all().sorted(by: "date", ascending: false).find()
+        self.data = ICloudModel.all().sorted(by: "text", ascending: false).find()
     }
     
     override func dataCount() -> Int {
@@ -61,23 +65,17 @@ class RestKitTableViewController: StackTableViewController {
     //MARK: - Cell
     
     override func configureCell(cell: UITableViewCell, indexPath: NSIndexPath) {
-        let formatter = NSDateFormatter()
-        formatter.dateFormat = "MMMM d yyyy - HH:mm:ss"
-        let model = self.data![indexPath.row] as RestKitModel
-        cell.textLabel?.text = model.name
-        cell.detailTextLabel?.text = formatter.stringFromDate(model.date)
+        let model = self.data![indexPath.row] as ICloudModel
+        cell.textLabel?.text = model.text
     }
     
     override func tableView(tableView: UITableView, commitEditingStyle editingStyle: UITableViewCellEditingStyle, forRowAtIndexPath indexPath: NSIndexPath) {
         if (editingStyle == .Delete) {
-            let model = self.data![indexPath.row] as RestKitModel
+            let model = self.data![indexPath.row] as ICloudModel
             model.beginWriting().delete().endWriting()
             self.fetchData()
             tableView.deleteRowsAtIndexPaths([indexPath], withRowAnimation: .Fade)
         }
     }
-    
-    override func cellIdentifier() -> String {
-        return "ModelCell"
-    }
+
 }

--- a/example/SugarRecordExample/Shared/Models/ICloudModel.swift
+++ b/example/SugarRecordExample/Shared/Models/ICloudModel.swift
@@ -1,0 +1,17 @@
+//
+//  ICloudModel.swift
+//  SugarRecordExample
+//
+//  Created by David Chavez on 2/19/15.
+//  Copyright (c) 2015 David Chavez. All rights reserved.
+//
+
+import Foundation
+import CoreData
+
+@objc(ICloudModel)
+class ICloudModel: NSManagedObject {
+
+    @NSManaged var text: String
+
+}

--- a/example/SugarRecordExample/Shared/Models/Models.xcdatamodeld/Models 2.xcdatamodel/contents
+++ b/example/SugarRecordExample/Shared/Models/Models.xcdatamodeld/Models 2.xcdatamodel/contents
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="6254" systemVersion="14B25" minimumToolsVersion="Xcode 4.3" macOSVersion="Automatic" iOSVersion="Automatic">
+<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="6254" systemVersion="14D72i" minimumToolsVersion="Xcode 4.3" macOSVersion="Automatic" iOSVersion="Automatic">
     <entity name="CoreDataModel" representedClassName="CoreDataModel" syncable="YES">
+        <attribute name="text" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="ICloudModel" representedClassName="ICloudModel" syncable="YES">
         <attribute name="text" optional="YES" attributeType="String" syncable="YES"/>
     </entity>
     <entity name="RestKitModel" representedClassName="RestKitModel" syncable="YES">
@@ -10,5 +13,6 @@
     <elements>
         <element name="CoreDataModel" positionX="-63" positionY="-18" width="128" height="60"/>
         <element name="RestKitModel" positionX="-45" positionY="9" width="128" height="73"/>
+        <element name="ICloudModel" positionX="-54" positionY="9" width="128" height="58"/>
     </elements>
 </model>

--- a/example/SugarRecordExample/Shared/Models/RealmModel.swift
+++ b/example/SugarRecordExample/Shared/Models/RealmModel.swift
@@ -9,6 +9,7 @@
 import Foundation
 import Realm
 
+@objc(RealmModel)
 class RealmModel: RLMObject {
     dynamic var name = ""
     dynamic var date = NSDate()

--- a/library/Core/SugarRecord.swift
+++ b/library/Core/SugarRecord.swift
@@ -58,6 +58,7 @@ public class SugarRecord {
         stack.initialize()
     }
     
+    
     /**
     Remove all the stacks from the list
     */

--- a/library/CoreData/Base/iCloudCDStack.swift
+++ b/library/CoreData/Base/iCloudCDStack.swift
@@ -163,7 +163,7 @@ public class iCloudCDStack: DefaultCDStack
     override public func dataBaseAddedClosure() -> CompletionClosure {
         return { [weak self] (error) -> () in
             if self == nil {
-                SugarRecordLogger.logLevelFatal.log("The stack was released whil trying to initialize it")
+                SugarRecordLogger.logLevelFatal.log("The stack was released while trying to initialize it")
                 return
             }
             else if error != nil {
@@ -174,6 +174,8 @@ public class iCloudCDStack: DefaultCDStack
             self!.mainContext = self!.createMainContext(self!.rootSavingContext)
             self!.addObservers()
             self!.stackInitialized = true
+            
+            NSNotificationCenter.defaultCenter().postNotificationName("iCloudStackInitialized", object: nil)
         }
     }
     

--- a/library/CoreData/Base/iCloudCDStack.swift
+++ b/library/CoreData/Base/iCloudCDStack.swift
@@ -335,7 +335,7 @@ public class iCloudCDStack: DefaultCDStack
     
     :param: notification Notification with these changes
     */
-    @objc internal func persistentStoreDidImportUbiquitousContentChanges(notification: NSNotification)
+    dynamic internal func persistentStoreDidImportUbiquitousContentChanges(notification: NSNotification)
     {
         SugarRecordLogger.logLevelVerbose.log("Changes detected from iCloud. Merging them into the current CoreData stack")
         self.rootSavingContext!.performBlock { [weak self] () -> Void in
@@ -355,7 +355,7 @@ public class iCloudCDStack: DefaultCDStack
     
     :param: notification Notification with these changes
     */
-    @objc internal func storesWillChange(notification: NSNotification)
+    dynamic internal func storesWillChange(notification: NSNotification)
     {
         SugarRecordLogger.logLevelVerbose.log("Stores will change, saving pending changes before changing store")
         self.saveChanges()
@@ -367,7 +367,7 @@ public class iCloudCDStack: DefaultCDStack
     
     :param: notification Notification with the information
     */
-    @objc internal func storeDidChange(notification: NSNotification)
+    dynamic internal func storeDidChange(notification: NSNotification)
     {
         SugarRecordLogger.logLevelVerbose.log("The persistent store of the psc did change")
         // Nothing to do here

--- a/library/CoreData/Base/iCloudCDStack.swift
+++ b/library/CoreData/Base/iCloudCDStack.swift
@@ -333,7 +333,7 @@ public class iCloudCDStack: DefaultCDStack
     
     :param: notification Notification with these changes
     */
-    internal func persistentStoreDidImportUbiquitousContentChanges(notification: NSNotification)
+    @objc internal func persistentStoreDidImportUbiquitousContentChanges(notification: NSNotification)
     {
         SugarRecordLogger.logLevelVerbose.log("Changes detected from iCloud. Merging them into the current CoreData stack")
         self.rootSavingContext!.performBlock { [weak self] () -> Void in
@@ -353,7 +353,7 @@ public class iCloudCDStack: DefaultCDStack
     
     :param: notification Notification with these changes
     */
-    internal func storesWillChange(notification: NSNotification)
+    @objc internal func storesWillChange(notification: NSNotification)
     {
         SugarRecordLogger.logLevelVerbose.log("Stores will change, saving pending changes before changing store")
         self.saveChanges()
@@ -365,7 +365,7 @@ public class iCloudCDStack: DefaultCDStack
     
     :param: notification Notification with the information
     */
-    internal func storeDidChange(notification: NSNotification)
+    @objc internal func storeDidChange(notification: NSNotification)
     {
         SugarRecordLogger.logLevelVerbose.log("The persistent store of the psc did change")
         // Nothing to do here


### PR DESCRIPTION
- RestKit example would crash when adding new entry
- iCloud stack would crash when initializing it (NSForwarding error)
- iCloud stack would crash because its initialized in background thread and you're able to use it before its done initializing -- as a (temp?) fix made it post a notification to know when its done

- Changed the example project to follow the same format throughout