### PR TITLE
added filter, map, to SugarRecordResults

### DIFF
--- a/library/Core/SugarRecordFinder.swift
+++ b/library/Core/SugarRecordFinder.swift
@@ -264,7 +264,7 @@ public class SugarRecordFinder
     */
     public func setPredicate<T: StringLiteralConvertible, R: StringLiteralConvertible>(byKey key: T, andValue value: R) -> SugarRecordFinder
     {
-        self.predicate = NSPredicate(format: "\(key) == \(value)")
+        self.predicate = NSPredicate(format: "\(key) == '\(value)'")
         return self
     }
     

--- a/library/Core/SugarRecordResults.swift
+++ b/library/Core/SugarRecordResults.swift
@@ -116,3 +116,22 @@ public class SRResultsGenerator: GeneratorType {
         return self.results[nextIndex--]
     }
 }
+
+//MARK: Convenience Methods Extension
+
+extension SugarRecordResults {
+    func filter<T>(predicate:(T) -> Bool) -> [T] {
+        var result = [T]()
+        for obj in self {
+            if predicate(obj as T) { result.append(obj as T) }
+        }
+        return result
+    }
+    func map<T, U>(transform:(T) -> (U)) -> [U] {
+        var result = [U]()
+        for obj in self {
+            result.append(transform(obj as T))
+        }
+        return result
+    }
+}


### PR DESCRIPTION
I first assumed theres a protocol to implement, but it looks like those are simply methods of Array/LazySequence/other types... So added as extension

One drawback is that force casting (as or as! depends on your Swift ver...) still needed inside closure, but output is then the type of casting. e.g.: 

    let olderUsers = allUsers.filter { ($0 as User).age > 30 }
    //olderUsers is type [User]