### PR TITLE
Make currentLevel public in SugarRecordLogger

### DIFF
--- a/library/Core/SugarRecordLogger.swift
+++ b/library/Core/SugarRecordLogger.swift
@@ -19,7 +19,7 @@ SugarRecordLogger is a logger to show messages coming from the library depending
 */
 public enum SugarRecordLogger: Int {
     /// Current SugarRecord log level
-    static var currentLevel: SugarRecordLogger = .logLevelInfo
+    public static var currentLevel: SugarRecordLogger = .logLevelInfo
     
     /// SugarRecord enum levels
     case logLevelFatal, logLevelError, logLevelWarn, logLevelInfo, logLevelVerbose


### PR DESCRIPTION
Currently we can't set the log level because currentLevel is private.  This change would make it public,